### PR TITLE
Fix email filter for user list

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -9,3 +9,5 @@ class User(AbstractUser):
     following = models.ManyToManyField('User', related_name='followers')
 
 
+    class Meta:
+        ordering = ['id']

--- a/core/views.py
+++ b/core/views.py
@@ -24,7 +24,7 @@ class UserSearchFilter(SearchFilter):
         return super().get_search_fields(view, request)
 class UserViewSet(ModelViewSet):
     filter_backends = [DjangoFilterBackend, UserSearchFilter]
-    filterset_fields = ['username']
+    filterset_fields = ['username', 'email']
     pagination_class = PageNumberPagination
     # permission_classes = [IsAuthenticated]
     queryset = User.objects.prefetch_related('following').all()

--- a/pollish/models.py
+++ b/pollish/models.py
@@ -32,9 +32,7 @@ class Community(models.Model):
     name = models.CharField(max_length=255)
     users = models.ManyToManyField(settings.AUTH_USER_MODEL, related_name='communities', blank=True)
     uuid = models.UUIDField(default=uuid4)
-
-
-
+    
 
 
 class Poll(models.Model):


### PR DESCRIPTION
I'm trying to add custom validation to the register screen, where after (debounced) # of keystrokes, there is a check to see if the email exists in the database.

There was a previous issue where any search with `?email=` would return all users, hence the form persistently thought that the user with that email already existed.

Should be good now 🥰